### PR TITLE
Add Future+Websocket

### DIFF
--- a/Sources/EngineExtensions/Future+WebSocket.swift
+++ b/Sources/EngineExtensions/Future+WebSocket.swift
@@ -1,0 +1,21 @@
+import Async
+import WebSocket
+import Foundation
+
+extension Future where Expectation == String {
+    public func send(to websocket: WebSocket) -> Future<Expectation> {
+        return self.flatMap(to: Expectation.self) { (data) in
+            websocket.send(string: data)
+            return self
+        }
+    }
+}
+
+extension Future where Expectation == Data {
+    public func send(to websocket: WebSocket) -> Future<Expectation> {
+        return self.flatMap(to: Expectation.self) { (data) in
+            websocket.send(data: data)
+            return self
+        }
+    }
+}

--- a/Sources/EngineExtensions/Future+WebSocket.swift
+++ b/Sources/EngineExtensions/Future+WebSocket.swift
@@ -2,6 +2,18 @@ import Async
 import WebSocket
 import Foundation
 
+
+/// EngineExtensions: Sends the expectation of self to a websocket.
+///
+///    router.websocket("demo") { (req, ws) in
+///         ws.onData({ (ws, msg) in
+///            _ = Future(msg)
+///                 .send(to: ws)
+///         })
+///     }
+///
+/// - Parameter websocket: The `WebSocket` to send the expectation to.
+/// - Returns: Passes through the expectation of `self` after sending to `websocket`
 extension Future where Expectation == String {
     public func send(to websocket: WebSocket) -> Future<Expectation> {
         return self.flatMap(to: Expectation.self) { (data) in
@@ -11,6 +23,18 @@ extension Future where Expectation == String {
     }
 }
 
+
+/// EngineExtensions: Sends the expectation of self to a websocket.
+///
+///    router.websocket("demo") { (req, ws) in
+///         ws.onString({ (ws, msg) in
+///            _ = Future(msg)
+///                 .send(to: ws)
+///         })
+///     }
+///
+/// - Parameter websocket: The `WebSocket` to send the expectation to,
+/// - Returns: Passes through the expectation of `self` after sending to `websocket`
 extension Future where Expectation == Data {
     public func send(to websocket: WebSocket) -> Future<Expectation> {
         return self.flatMap(to: Expectation.self) { (data) in

--- a/Sources/EngineExtensions/FutureExtensions.swift
+++ b/Sources/EngineExtensions/FutureExtensions.swift
@@ -3,6 +3,9 @@ import WebSocket
 import Foundation
 
 
+// MARK: - Methods
+// MARK: - WebSockets
+
 /// EngineExtensions: Sends the expectation of self to a websocket.
 ///
 ///    router.websocket("demo") { (req, ws) in


### PR DESCRIPTION
Should ease the integration of Websockets into promise chains.

Usage example:

```swift
router.websocket("message") { (req, websocket) in
    websocket.onString { (ws, msg) in
        let decoder = JSONDecoder()
        let encoder = JSONEncoder()
        let message = try decoder.decode(Message.self, from: msg.data(using: .utf8)!)
        
        req.withPooledConnection(to: .psql, closure: { (conn) in
            return conn
                .query(Message.self)
                .save(message)
                .flatMap(to: [Message].self) { (_) -> Future<[Message]> in
                    return conn.query(Message.self).all()
                }.map(to: String.self) { (allMessages) in
                    guard let allJSONMessages = try encoder.encode(allMessages).toString()
                        else {throw Abort(.internalServerError)}
                    return allJSONMessages
                }.send(to: ws) // This is the addition
                .catch({ (err) in
                    print(err)
                })
        })
    }
}
```